### PR TITLE
Fixed wrong solr path

### DIFF
--- a/core/src/main/resources/runtime-properties/default-shared.properties
+++ b/core/src/main/resources/runtime-properties/default-shared.properties
@@ -87,5 +87,3 @@ admin.baseurl.secure=false
 admin.baseurl.context=admin
 
 crossapp.requireSsl=false
-
-solr.server.workingDirectory=/Users/ncrum/code/broadleaf-react-starter


### PR DESCRIPTION
api server fails on startup. Use the default Solr working directory instead